### PR TITLE
Exclude SPO headings polluting selection logic from sept. 25

### DIFF
--- a/puntobello-inpagenav-anchors-spwp/src/webparts/inPageNav/services/SharePointService.ts
+++ b/puntobello-inpagenav-anchors-spwp/src/webparts/inPageNav/services/SharePointService.ts
@@ -81,6 +81,14 @@ export default class SharePointService {
         // Filter headings based on props to maintain natural order
         const filteredHeadings = headings.filter(heading => {
             const tagName = heading.tagName.toLowerCase();
+            const className = heading.getAttribute('class') || '';
+
+            // Exclude web part titles that have the lineHeight1_4 class
+            // Web part titles typically have: "headingSpacingAbove headingSpacingBelow lineHeight1_4"
+            if (className.includes('lineHeight1_4')) {
+                return false;
+            }
+
             return (tagName === 'h2' && props.processH2) ||
                    (tagName === 'h3' && props.processH3) ||
                    (tagName === 'h4' && props.processH4);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * In-page navigation now skips visually styled headings that shouldn’t appear in the anchor list, reducing clutter and improving relevance.
  * Maintains existing heading level settings (H2/H3/H4) while refining which headings are included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->