### PR TITLE
Filter out empty and invalid heading tags

### DIFF
--- a/puntobello-inpagenav-anchors-spwp/src/webparts/inPageNav/services/SharePointService.ts
+++ b/puntobello-inpagenav-anchors-spwp/src/webparts/inPageNav/services/SharePointService.ts
@@ -115,6 +115,12 @@ export default class SharePointService {
     
         for (const heading of headings) {
             const cleanAnchorTag = heading.textContent || '';
+
+            // Skip headings with no meaningful content (empty or whitespace only)
+            if (!cleanAnchorTag.trim()) {
+                continue;
+            }
+
             const tagID = this.getAnchorID(cleanAnchorTag);
             const finalAnchorTag = this.stripAlphaNumericOrdering(cleanAnchorTag);
             const tagName = heading.tagName.toLowerCase();


### PR DESCRIPTION
## Summary
Skip headings with no meaningful content (empty or whitespace only) when generating anchor tags for in-page navigation. This prevents empty entries in the navigation list.

## Changes
- Add check in `getAnchorTagsList()` to skip headings where `textContent` is empty or contains only whitespace

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved in-page navigation by preventing anchor tags from being generated for empty or whitespace-only headings, resulting in cleaner and more reliable navigation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->